### PR TITLE
code to handle no existing camera, temporarily hide objects from asset preview render, and UI panel

### DIFF
--- a/asset_snapshot.py
+++ b/asset_snapshot.py
@@ -127,6 +127,7 @@ class OBJECT_PT_panel(Panel):
         scene = context.scene
         tool = scene.asset_snapshot
         layout.prop(tool, "resolution")
+        layout.label(text='Sometimes crashes. SAVE YOUR FILES', icon="ERROR")
         layout.operator("view3d.object_preview")
         layout.operator("view3d.asset_snaphot_collection")
 

--- a/asset_snapshot.py
+++ b/asset_snapshot.py
@@ -27,7 +27,13 @@ def snapshot(self,context,ob):
     hold_x = bpy.context.scene.render.resolution_x
     hold_y = bpy.context.scene.render.resolution_y 
     filepath = bpy.context.scene.render.filepath
-
+    
+    # Find objects that are hidden in viewport and hide them in render
+    tempHidden = []
+    for o in bpy.data.objects:
+        if o.hide_get() == True:
+            o.hide_render = True
+            tempHidden.append(o)
 
     # Change Settings
     bpy.context.scene.render.resolution_y = self.resolution
@@ -46,6 +52,9 @@ def snapshot(self,context,ob):
     override['id'] = ob
     bpy.ops.ed.lib_id_load_custom_preview(override,filepath=file)
     
+    # Unhide the objects hidden for the render
+    for o in tempHidden:
+        o.hide_render = False
     
     #Cleanup
     context.area.type = areatype

--- a/asset_snapshot.py
+++ b/asset_snapshot.py
@@ -14,19 +14,20 @@ bl_info = {
     'category': 'View3d',
     "blender": (3, 0, 0),
 }
-    
+
+
 def snapshot(self,context,ob):
     #Save some basic settings
     areatype = context.area.type
-    camera = bpy.context.scene.camera
-    if camera == None:
+    if bpy.context.scene.camera == None:
         bpy.ops.object.camera_add()
-        camera = bpy.context.scene.camera
+    camera = bpy.context.scene.camera    
     camerapos = camera.location.copy()
     camerarot = camera.rotation_euler.copy()
     hold_x = bpy.context.scene.render.resolution_x
     hold_y = bpy.context.scene.render.resolution_y 
     filepath = bpy.context.scene.render.filepath
+    
     
     # Find objects that are hidden in viewport and hide them in render
     tempHidden = []
@@ -34,7 +35,8 @@ def snapshot(self,context,ob):
         if o.hide_get() == True:
             o.hide_render = True
             tempHidden.append(o)
-
+    
+    
     # Change Settings
     bpy.context.scene.render.resolution_y = self.resolution
     bpy.context.scene.render.resolution_x = self.resolution
@@ -42,8 +44,8 @@ def snapshot(self,context,ob):
         bpy.ops.view3d.camera_to_view()  
     bpy.context.scene.render.filepath = os.path.join("/tmp", ob.name) 
     file = os.path.join("/tmp", ob.name)+".png"
-
-
+    
+    
     #Render File, Mark Asset and Set Image
     bpy.ops.render.render(write_still = True)
     ob.asset_mark()
@@ -52,9 +54,11 @@ def snapshot(self,context,ob):
     override['id'] = ob
     bpy.ops.ed.lib_id_load_custom_preview(override,filepath=file)
     
+    
     # Unhide the objects hidden for the render
     for o in tempHidden:
         o.hide_render = False
+    
     
     #Cleanup
     context.area.type = areatype
@@ -65,6 +69,7 @@ def snapshot(self,context,ob):
     camera.rotation_euler = camerarot
     bpy.context.scene.render.filepath = filepath
     bpy.ops.view3d.view_camera()
+
 
 class AssetSnapshotCollection(Operator):
     """Create a preview of a collection"""
@@ -88,7 +93,8 @@ class AssetSnapshotCollection(Operator):
     def execute(self, context):
         snapshot(self, context,context.collection)
         return {'FINISHED'}
-     
+
+
 class AssetSnapshotObject(Operator):
     """Create an asset preview of an object"""
     bl_idname = "view3d.object_preview"

--- a/asset_snapshot.py
+++ b/asset_snapshot.py
@@ -18,7 +18,10 @@ bl_info = {
 def snapshot(self,context,ob):
     #Save some basic settings
     areatype = context.area.type
-    camera = bpy.context.scene.camera  
+    camera = bpy.context.scene.camera
+    if camera == None:
+        bpy.ops.object.camera_add()
+        camera = bpy.context.scene.camera
     camerapos = camera.location.copy()
     camerarot = camera.rotation_euler.copy()
     hold_x = bpy.context.scene.render.resolution_x
@@ -34,6 +37,7 @@ def snapshot(self,context,ob):
     bpy.context.scene.render.filepath = os.path.join("/tmp", ob.name) 
     file = os.path.join("/tmp", ob.name)+".png"
 
+
     #Render File, Mark Asset and Set Image
     bpy.ops.render.render(write_still = True)
     ob.asset_mark()
@@ -41,6 +45,7 @@ def snapshot(self,context,ob):
     context.area.type = 'FILE_BROWSER'
     override['id'] = ob
     bpy.ops.ed.lib_id_load_custom_preview(override,filepath=file)
+    
     
     #Cleanup
     context.area.type = areatype
@@ -57,7 +62,6 @@ class AssetSnapshotCollection(Operator):
     bl_idname = "view3d.asset_snaphot_collection"
     bl_label = "Asset Snapshot - Collection"
     bl_options = {'REGISTER', 'UNDO'}
-
     resolution: IntProperty(
             name="Preview Resolution",
             description="Resolution to render the preview",
@@ -65,17 +69,13 @@ class AssetSnapshotCollection(Operator):
             soft_max=500,
             default=256
             )
-    
     @classmethod
     def poll(cls, context):
         if context.area.type != 'VIEW_3D':
             return False
-        
         if context.collection == None:
             return False
-
         return True
-
     def execute(self, context):
         snapshot(self, context,context.collection)
         return {'FINISHED'}
@@ -85,7 +85,6 @@ class AssetSnapshotObject(Operator):
     bl_idname = "view3d.object_preview"
     bl_label = "Asset Snapshot - Object"
     bl_options = {'REGISTER', 'UNDO'}
-
     resolution: IntProperty(
             name="Preview Resolution",
             description="Resolution to render the preview",
@@ -93,16 +92,13 @@ class AssetSnapshotObject(Operator):
             soft_max=500,
             default=250
             )
-
     @classmethod
     def poll(cls, context):
         if context.area.type != 'VIEW_3D':
             return False
         if context.view_layer.objects.active == None:
             return False
-
         return True
-
     def execute(self, context):
         snapshot(self, context, bpy.context.view_layer.objects.active)
         return {'FINISHED'}
@@ -118,6 +114,3 @@ def unregister():
 
 if __name__ == "__main__":
     register()
-
-    # test call
-    #bpy.ops.view3d.collection_asset_preview()

--- a/asset_snapshot.py
+++ b/asset_snapshot.py
@@ -1,13 +1,19 @@
 import bpy
-from bpy.types import Operator
+from bpy.types import (Panel,
+                       # Menu,
+                       Operator,
+                       PropertyGroup,
+                       )
 from bpy.props import (
         # FloatProperty,
         IntProperty,
         # BoolProperty,
         # StringProperty,
-        # FloatVectorProperty
+        # FloatVectorProperty,
+        PointerProperty,
         )
 import os
+
 
 bl_info = {
     'name': 'Asset Snapshot',
@@ -17,6 +23,8 @@ bl_info = {
 
 
 def snapshot(self,context,ob):
+    scene = context.scene
+    tool = scene.asset_snapshot
     #Save some basic settings
     areatype = context.area.type
     if bpy.context.scene.camera == None:
@@ -27,25 +35,19 @@ def snapshot(self,context,ob):
     hold_x = bpy.context.scene.render.resolution_x
     hold_y = bpy.context.scene.render.resolution_y 
     filepath = bpy.context.scene.render.filepath
-    
-    
     # Find objects that are hidden in viewport and hide them in render
     tempHidden = []
     for o in bpy.data.objects:
         if o.hide_get() == True:
             o.hide_render = True
             tempHidden.append(o)
-    
-    
     # Change Settings
-    bpy.context.scene.render.resolution_y = self.resolution
-    bpy.context.scene.render.resolution_x = self.resolution
+    bpy.context.scene.render.resolution_y = tool.resolution
+    bpy.context.scene.render.resolution_x = tool.resolution
     if bpy.ops.view3d.camera_to_view.poll():
         bpy.ops.view3d.camera_to_view()  
     bpy.context.scene.render.filepath = os.path.join("/tmp", ob.name) 
     file = os.path.join("/tmp", ob.name)+".png"
-    
-    
     #Render File, Mark Asset and Set Image
     bpy.ops.render.render(write_still = True)
     ob.asset_mark()
@@ -53,13 +55,9 @@ def snapshot(self,context,ob):
     context.area.type = 'FILE_BROWSER'
     override['id'] = ob
     bpy.ops.ed.lib_id_load_custom_preview(override,filepath=file)
-    
-    
     # Unhide the objects hidden for the render
     for o in tempHidden:
         o.hide_render = False
-    
-    
     #Cleanup
     context.area.type = areatype
     os.unlink(file)
@@ -71,18 +69,21 @@ def snapshot(self,context,ob):
     bpy.ops.view3d.view_camera()
 
 
-class AssetSnapshotCollection(Operator):
-    """Create a preview of a collection"""
-    bl_idname = "view3d.asset_snaphot_collection"
-    bl_label = "Asset Snapshot - Collection"
-    bl_options = {'REGISTER', 'UNDO'}
-    resolution: IntProperty(
+class properties(PropertyGroup):
+    resolution : IntProperty(
             name="Preview Resolution",
             description="Resolution to render the preview",
             min=1,
             soft_max=500,
             default=256
             )
+
+
+class AssetSnapshotCollection(Operator):
+    """Create a preview of a collection"""
+    bl_idname = "view3d.asset_snaphot_collection"
+    bl_label = "Asset Snapshot - Collection"
+    bl_options = {'REGISTER', 'UNDO'}
     @classmethod
     def poll(cls, context):
         if context.area.type != 'VIEW_3D':
@@ -100,13 +101,6 @@ class AssetSnapshotObject(Operator):
     bl_idname = "view3d.object_preview"
     bl_label = "Asset Snapshot - Object"
     bl_options = {'REGISTER', 'UNDO'}
-    resolution: IntProperty(
-            name="Preview Resolution",
-            description="Resolution to render the preview",
-            min=1,
-            soft_max=500,
-            default=250
-            )
     @classmethod
     def poll(cls, context):
         if context.area.type != 'VIEW_3D':
@@ -119,13 +113,39 @@ class AssetSnapshotObject(Operator):
         return {'FINISHED'}
 
 
+class OBJECT_PT_panel(Panel):
+    bl_label = "asset_snapshot"
+    bl_idname = "OBJECT_PT_asset_snapshot_panel"
+    bl_category = "asset_snapshot"
+    bl_space_type = "VIEW_3D"   
+    bl_region_type = "UI"
+    @classmethod
+    def poll(self,context):
+        return context.mode
+    def draw(self, context):
+        layout = self.layout
+        scene = context.scene
+        tool = scene.asset_snapshot
+        layout.prop(tool, "resolution")
+        layout.operator("view3d.object_preview")
+        layout.operator("view3d.asset_snaphot_collection")
+
+
 def register():
+    bpy.utils.register_class(properties)
     bpy.utils.register_class(AssetSnapshotCollection)
     bpy.utils.register_class(AssetSnapshotObject)
+    bpy.utils.register_class(OBJECT_PT_panel)
+    
+    bpy.types.Scene.asset_snapshot = PointerProperty(type=properties)
 
 def unregister():
+    bpy.utils.unregister_class(properties)
     bpy.utils.unregister_class(AssetSnapshotCollection)
     bpy.utils.unregister_class(AssetSnapshotObject)
+    bpy.utils.unregister_class(OBJECT_PT_panel)
+    
+    del bpy.types.Scene.asset_snapshot
 
 if __name__ == "__main__":
     register()


### PR DESCRIPTION
* Code that handles no camera in scene.
I noticed that it would spit out a fat error if you try and create an asset preview without a camera in your scene, so I added a couple lines of code to add a camera to the scene if there isn't one.
![image](https://user-images.githubusercontent.com/65134690/131553480-f615287a-ee29-4be1-9aa1-5a8194f059b6.png)


* Temporarily hide objects from asset preview render.
Made it so that any objects that are hidden in the viewport are also temporarily hidden in renders for the asset preview render, which makes hiding objects from the asset preview renders a bit quicker and easier.
![image](https://user-images.githubusercontent.com/65134690/131553420-1285d81b-97ac-407d-8b7d-2082d0371dc9.png)
![image](https://user-images.githubusercontent.com/65134690/131553441-13e2ae44-f813-4c7c-aad0-c0b09b23fa7a.png)

* UI panel.
Added a simple UI panel with some buttons to call the preview rendering functions and a prop for the preview resolution
![image](https://user-images.githubusercontent.com/65134690/131553252-b0982dec-7f48-4a42-b385-146aa2f31cfe.png)
